### PR TITLE
57 yankee swap fewer calls to valuation function

### DIFF
--- a/scripts/general_yankee_swap.py
+++ b/scripts/general_yankee_swap.py
@@ -12,7 +12,7 @@ from fair.metrics import leximin, nash_welfare, utilitarian_welfare
 from fair.optimization import StudentAllocationProgram
 from fair.simulation import RenaissanceMan
 
-NUM_STUDENTS = 50
+NUM_STUDENTS = 3
 MAX_COURSES_PER_TOPIC = 5
 MAX_COURSES_TOTAL = 6
 EXCEL_SCHEDULE_PATH = os.path.join(
@@ -78,8 +78,14 @@ X = general_yankee_swap(students, schedule)
 print("utilitarian welfare: ", utilitarian_welfare(X[0], students, schedule))
 print("nash welfare: ", nash_welfare(X[0], students, schedule))
 print("leximin vector: ", leximin(X[0], students, schedule))
-print("total bundles evaluated", sum([student.student.valuation._value_ct for student in students]))
-print("unique bundles evaluated", sum([student.student.valuation._unique_value_ct for student in students]))
+print(
+    "total bundles evaluated",
+    sum([student.student.valuation._value_ct for student in students]),
+)
+print(
+    "unique bundles evaluated",
+    sum([student.student.valuation._unique_value_ct for student in students]),
+)
 
 if FIND_OPTIMAL:
     orig_students = [student.student for student in students]

--- a/scripts/general_yankee_swap.py
+++ b/scripts/general_yankee_swap.py
@@ -12,9 +12,9 @@ from fair.metrics import leximin, nash_welfare, utilitarian_welfare
 from fair.optimization import StudentAllocationProgram
 from fair.simulation import RenaissanceMan
 
-NUM_STUDENTS = 3
+NUM_STUDENTS = 50
 MAX_COURSES_PER_TOPIC = 5
-MAX_COURSES_TOTAL = 5
+MAX_COURSES_TOTAL = 6
 EXCEL_SCHEDULE_PATH = os.path.join(
     os.path.dirname(__file__), "../resources/fall2023schedule-2-cat.xlsx"
 )
@@ -78,14 +78,8 @@ X = general_yankee_swap(students, schedule)
 print("utilitarian welfare: ", utilitarian_welfare(X[0], students, schedule))
 print("nash welfare: ", nash_welfare(X[0], students, schedule))
 print("leximin vector: ", leximin(X[0], students, schedule))
-print(
-    "total bundles evaluated",
-    sum([student.student.valuation._value_ct for student in students]),
-)
-print(
-    "unique bundles evaluated",
-    sum([student.student.valuation._unique_value_ct for student in students]),
-)
+print("total bundles evaluated", sum([student.student.valuation._value_ct for student in students]))
+print("unique bundles evaluated", sum([student.student.valuation._unique_value_ct for student in students]))
 
 if FIND_OPTIMAL:
     orig_students = [student.student for student in students]

--- a/scripts/general_yankee_swap.py
+++ b/scripts/general_yankee_swap.py
@@ -12,7 +12,7 @@ from fair.metrics import leximin, nash_welfare, utilitarian_welfare
 from fair.optimization import StudentAllocationProgram
 from fair.simulation import RenaissanceMan
 
-NUM_STUDENTS = 3
+NUM_STUDENTS = 100
 MAX_COURSES_PER_TOPIC = 5
 MAX_COURSES_TOTAL = 6
 EXCEL_SCHEDULE_PATH = os.path.join(

--- a/scripts/general_yankee_swap.py
+++ b/scripts/general_yankee_swap.py
@@ -12,9 +12,9 @@ from fair.metrics import leximin, nash_welfare, utilitarian_welfare
 from fair.optimization import StudentAllocationProgram
 from fair.simulation import RenaissanceMan
 
-NUM_STUDENTS = 100
+NUM_STUDENTS = 3
 MAX_COURSES_PER_TOPIC = 5
-MAX_COURSES_TOTAL = 6
+MAX_COURSES_TOTAL = 5
 EXCEL_SCHEDULE_PATH = os.path.join(
     os.path.dirname(__file__), "../resources/fall2023schedule-2-cat.xlsx"
 )

--- a/src/fair/agent.py
+++ b/src/fair/agent.py
@@ -27,13 +27,12 @@ def exchange_contribution(
     Returns:
         bool: True if utility can be improved; False otherwise
     """
-    
+
     if og_item == new_item:
         return False
 
     for i in range(len(bundle)):
         if bundle[i] == new_item:
-            # print(bundle[i], new_item)
             return False
 
     T0 = bundle.copy()

--- a/src/fair/agent.py
+++ b/src/fair/agent.py
@@ -71,6 +71,8 @@ def marginal_contribution(
     Returns:
         Any: Change in value
     """
+    if item in bundle:
+        return 0
     T = bundle.copy()
     current_val = valuation.value(T)
     T.append(item)

--- a/src/fair/agent.py
+++ b/src/fair/agent.py
@@ -27,11 +27,13 @@ def exchange_contribution(
     Returns:
         bool: True if utility can be improved; False otherwise
     """
-    og_val = valuation.value(bundle)
+    
+    if og_item == new_item:
+        return False
 
     for i in range(len(bundle)):
         if bundle[i] == new_item:
-            print(bundle[i], new_item)
+            # print(bundle[i], new_item)
             return False
 
     T0 = bundle.copy()
@@ -45,9 +47,8 @@ def exchange_contribution(
     T0.pop(index[0])
     T0.append(new_item)
 
+    og_val = valuation.value(bundle)
     new_val = valuation.value(T0)
-    if og_item == new_item:
-        return False
     if og_val == new_val:
         return True
     else:

--- a/src/fair/allocation.py
+++ b/src/fair/allocation.py
@@ -153,8 +153,9 @@ def add_agent_to_exchange_graph(G, X, items, agents, agent_picked):
     agent = agents[agent_picked]
     for i in agent.get_desired_items_indexes(items):
         g = items[i]
-        if agents[agent_picked].marginal_contribution(bundle, g) == 1:
-            G.add_edge("s", i)
+        if g not in bundle:
+            if agents[agent_picked].marginal_contribution(bundle, g) == 1:
+                G.add_edge("s", i)
     return G
 
 

--- a/src/fair/allocation.py
+++ b/src/fair/allocation.py
@@ -188,19 +188,20 @@ def build_exchange_graph(X, items, agents):
                     exchange_graph.add_edge(item_index, item_2_index)
     return exchange_graph
 
-def get_multiple_agents_desired_items(agents_indexes,agents,items):
+
+def get_multiple_agents_desired_items(agents_indexes, agents, items):
     lis = []
     for agent_index in agents_indexes:
         agent = agents[agent_index]
         lis = lis + agent.get_desired_items_indexes(items)
     return list(set(lis))
 
-def get_multiple_agents_bundles(agents_indexes,X):
+
+def get_multiple_agents_bundles(agents_indexes, X):
     lis = []
     for agent_index in agents_indexes:
-        lis = lis + get_bundle_indexes_from_allocation_matrix(X,agent_index)
+        lis = lis + get_bundle_indexes_from_allocation_matrix(X, agent_index)
     return list(set(lis))
-
 
 
 def update_exchange_graph(X, G, path_og, agents, items, agents_involved):
@@ -209,15 +210,19 @@ def update_exchange_graph(X, G, path_og, agents, items, agents_involved):
     last_item = path[-1]
     if X[last_item, len(agents)] == 0:
         G.remove_edge(last_item, "t")
-    agents_involved_desired_items = get_multiple_agents_desired_items(agents_involved,agents,items)
+    agents_involved_desired_items = get_multiple_agents_desired_items(
+        agents_involved, agents, items
+    )
     agents_involved_bundles = get_multiple_agents_bundles(agents_involved, X)
     for item_idx in agents_involved_bundles:
         item_1 = items[item_idx]
-        owners = list(get_owners_list(X,item_idx))
+        owners = list(get_owners_list(X, item_idx))
         if len(agents) in owners:
             owners.remove(len(agents))
-        owners_desired_items = get_multiple_agents_desired_items(owners,agents,items)
-        items_to_loop_over = list(set(agents_involved_desired_items+owners_desired_items))
+        owners_desired_items = get_multiple_agents_desired_items(owners, agents, items)
+        items_to_loop_over = list(
+            set(agents_involved_desired_items + owners_desired_items)
+        )
         for item_2_idx in items_to_loop_over:
             if item_2_idx != item_idx:
                 item_2 = items[item_2_idx]

--- a/src/fair/allocation.py
+++ b/src/fair/allocation.py
@@ -150,7 +150,8 @@ def find_shortest_path(G, start, end):
 def add_agent_to_exchange_graph(G, X, items, agents, agent_picked):
     G.add_node("s")
     bundle = get_bundle_from_allocation_matrix(X, items, agent_picked)
-    for i in range(len(items)):
+    agent = agents[agent_picked]
+    for i in agent.get_desired_items_indexes(items):
         g = items[i]
         if agents[agent_picked].marginal_contribution(bundle, g) == 1:
             G.add_edge("s", i)
@@ -186,6 +187,20 @@ def build_exchange_graph(X, items, agents):
                     exchange_graph.add_edge(item_index, item_2_index)
     return exchange_graph
 
+def get_multiple_agents_desired_items(agents_indexes,agents,items):
+    lis = []
+    for agent_index in agents_indexes:
+        agent = agents[agent_index]
+        lis = lis + agent.get_desired_items_indexes(items)
+    return list(set(lis))
+
+def get_multiple_agents_bundles(agents_indexes,X):
+    lis = []
+    for agent_index in agents_indexes:
+        lis = lis + get_bundle_indexes_from_allocation_matrix(X,agent_index)
+    return list(set(lis))
+
+
 
 def update_exchange_graph(X, G, path_og, agents, items, agents_involved):
     path = path_og.copy()
@@ -193,32 +208,36 @@ def update_exchange_graph(X, G, path_og, agents, items, agents_involved):
     last_item = path[-1]
     if X[last_item, len(agents)] == 0:
         G.remove_edge(last_item, "t")
-    for agent_index in agents_involved:
-        bundle_indexes = get_bundle_indexes_from_allocation_matrix(X, agent_index)
-        for item_idx in bundle_indexes:
-            item_1 = items[item_idx]
-            owners = get_owners_list(X, item_idx)
-            for item_2_idx in range(len(items)):
-                if item_2_idx != item_idx:
-                    item_2 = items[item_2_idx]
-                    exchangeable = False
-                    for owner in owners:
-                        if owner != len(agents):
-                            agent = agents[owner]
-                            bundle_owner = get_bundle_from_allocation_matrix(
-                                X, items, owner
-                            )
-                            willing_owner = agent.exchange_contribution(
-                                bundle_owner, item_1, item_2
-                            )
-                            if willing_owner:
-                                exchangeable = True
-                    if exchangeable:
-                        if not G.has_edge(item_idx, item_2_idx):
-                            G.add_edge(item_idx, item_2_idx)
-                    else:
-                        if G.has_edge(item_idx, item_2_idx):
-                            G.remove_edge(item_idx, item_2_idx)
+    agents_involved_desired_items = get_multiple_agents_desired_items(agents_involved,agents,items)
+    agents_involved_bundles = get_multiple_agents_bundles(agents_involved, X)
+    for item_idx in agents_involved_bundles:
+        item_1 = items[item_idx]
+        owners = list(get_owners_list(X,item_idx))
+        if len(agents) in owners:
+            owners.remove(len(agents))
+        owners_desired_items = get_multiple_agents_desired_items(owners,agents,items)
+        items_to_loop_over = list(set(agents_involved_desired_items+owners_desired_items))
+        for item_2_idx in items_to_loop_over:
+            if item_2_idx != item_idx:
+                item_2 = items[item_2_idx]
+                exchangeable = False
+                for owner in owners:
+                    if owner != len(agents):
+                        agent = agents[owner]
+                        bundle_owner = get_bundle_from_allocation_matrix(
+                            X, items, owner
+                        )
+                        willing_owner = agent.exchange_contribution(
+                            bundle_owner, item_1, item_2
+                        )
+                        if willing_owner:
+                            exchangeable = True
+                if exchangeable:
+                    if not G.has_edge(item_idx, item_2_idx):
+                        G.add_edge(item_idx, item_2_idx)
+                else:
+                    if G.has_edge(item_idx, item_2_idx):
+                        G.remove_edge(item_idx, item_2_idx)
     return G
 
 

--- a/src/fair/allocation.py
+++ b/src/fair/allocation.py
@@ -153,8 +153,11 @@ def add_agent_to_exchange_graph(G, X, items, agents, agent_picked):
     agent = agents[agent_picked]
     for i in agent.get_desired_items_indexes(items):
         g = items[i]
-        if g not in bundle and agents[agent_picked].marginal_contribution(bundle, g) == 1:
-                G.add_edge("s", i)
+        if (
+            g not in bundle
+            and agents[agent_picked].marginal_contribution(bundle, g) == 1
+        ):
+            G.add_edge("s", i)
     return G
 
 

--- a/src/fair/allocation.py
+++ b/src/fair/allocation.py
@@ -153,8 +153,7 @@ def add_agent_to_exchange_graph(G, X, items, agents, agent_picked):
     agent = agents[agent_picked]
     for i in agent.get_desired_items_indexes(items):
         g = items[i]
-        if g not in bundle:
-            if agents[agent_picked].marginal_contribution(bundle, g) == 1:
+        if g not in bundle and agents[agent_picked].marginal_contribution(bundle, g) == 1:
                 G.add_edge("s", i)
     return G
 


### PR DESCRIPTION
Changes in agent.py:

- exchange_contribution function: we first evaluate certain criteria to decide whether an item will contribute before computing its valuation function: check if the item is the same and also check if the item is already in the bundle. It might not be necessary, but might reduce the number of calls if we also check if the item is in the list of desired items (the allocation algorithms should be taking care of that but you never know).

Changes in allocation.py:

- add_agent_to_exchange_graph: While adding edges, consider only edges to desired items different to the ones already owned (original code would go over every item).
- update_exchange_graph: modified the looping structure to make fewer calls by going only through desired items and avoiding visiting some items twice. Added functions get_multiple_agents_desired_items and get_multiple_agents_bundles to facilitate this.